### PR TITLE
typo fixes

### DIFF
--- a/input/vpnclient.xml
+++ b/input/vpnclient.xml
@@ -4701,7 +4701,7 @@ expected to enforce.<h:p/>
                 The evaluator shall configure the TOE to use a supported HOTP factor then:
                 <testlist>
                 <test>Attempt to establish a connection using a factor from a different client, the test passes if the client fails to connect.
-                </test><test>Attempt multiple connections outside the boundry set in FIA_HOTP_EXT.1.6 and verify the remediation is triggered.  The test passes if remediation is triggered as defined in the selections and assignments.
+                </test><test>Attempt multiple connections outside the boundary set in FIA_HOTP_EXT.1.6 and verify the remediation is triggered.  The test passes if remediation is triggered as defined in the selections and assignments.
                 </test><test>Attempt to use a HOTP that is outside of the value allowed with for resynchronization. The test passes if the client fails to connect.
                 </test><test>Attempt to connect with a valid HOTP, disconnect and attempt to authenticate again with the same HOTP value.  The test passes if the client connects the first time and fails to connect the second time. If the HOTP generated is duplicated the test may be repeated.
                 </test>

--- a/input/vpnclient.xml
+++ b/input/vpnclient.xml
@@ -4433,7 +4433,7 @@ expected to enforce.<h:p/>
               <h:p/>This requirement is selection dependent on FIA_PSK_EXT.1. 
               </note>
             <aactivity>
-              <TSS>The evaluator shall also examine the TSS to ensure it describes the process by which the bit-based pre-shared keys used. If generated is selected the evaluator shall confirm that this process uses the RBG specified in FCS_RBG_EXT.1. 
+              <TSS>The evaluator shall examine the TSS to ensure it describes the process by which the bit-based pre-shared keys used. If generated is selected the evaluator shall confirm that this process uses the RBG specified in FCS_RBG_EXT.1. 
                 
                 <h:p/>Support for supported length: The evaluators shall check to ensure that the TSS describes the allowable ranges for PSK lengths, and that at least 64 characters or a length defined by the platform may be specified by the user.
                 
@@ -4701,7 +4701,7 @@ expected to enforce.<h:p/>
                 The evaluator shall configure the TOE to use a supported HOTP factor then:
                 <testlist>
                 <test>Attempt to establish a connection using a factor from a different client, the test passes if the client fails to connect.
-                </test><test>Attempt multiple connections outside the bounty set in FIA_HOTP_EXT.1.6 and verify the remediation is triggered.  The test passes if remediation is triggered as defined in the selections and assignments.
+                </test><test>Attempt multiple connections outside the boundry set in FIA_HOTP_EXT.1.6 and verify the remediation is triggered.  The test passes if remediation is triggered as defined in the selections and assignments.
                 </test><test>Attempt to use a HOTP that is outside of the value allowed with for resynchronization. The test passes if the client fails to connect.
                 </test><test>Attempt to connect with a valid HOTP, disconnect and attempt to authenticate again with the same HOTP value.  The test passes if the client connects the first time and fails to connect the second time. If the HOTP generated is duplicated the test may be repeated.
                 </test>


### PR DESCRIPTION
 (bounty -> boundary)

removed an "also" that didn't need to be there