### PR TITLE
EAP-TTLS is RFC 5281, not RFC 5881

### DIFF
--- a/input/vpnclient.xml
+++ b/input/vpnclient.xml
@@ -4444,7 +4444,7 @@ expected to enforce.<h:br/><h:br/>
               The TSF shall implement
               <selectables>
                 <selectable>EAP-TLS protocol as specified in RFC 5216</selectable>
-                <selectable>EAP-TTLS as specified in RFC 5881</selectable>
+                <selectable>EAP-TTLS as specified in RFC 5281</selectable>
               </selectables>
               as updated by RFC 8996 with TLS implemented using mutual authentication in accordance with the TLS functional package.
             </title>


### PR DESCRIPTION
Fix the typo reported in #20 